### PR TITLE
added leading text and BBIP-0001 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # BBIPs
 Byteball Improvement Proposals
+
+
+People wishing to submit BBIPs, first should propose their idea or document to the [Byteball Slack](http://slack.byteball.org). After discussion they should create a pull request to this git repository with the proposed BBIP. After copy-editing and acceptance, it will be published here.
+
+We are fairly liberal with approving BBIPs, and try not to be too involved in decision making on behalf of the community. The exception is in very rare cases of dispute resolution when a decision is contentious and cannot be agreed upon. In those cases, the conservative option will always be preferred.
+
+Having a BBIP here does not make it a formally accepted standard until its status becomes Final or Active.
+
+
+|Number|Layer|Title|Owner|Type|Status|
+|------|-----|-----|-----|----|------|
+|[1](bbip-0001.md)||BBIP Purpose and Guidelines|Peter Miklos|Process|Draft|


### PR DESCRIPTION
This merge request adds some introductory text to the README and includes a table with the first BBIP. The content is mostly lifted from the README of Bitcoin's BIPs.